### PR TITLE
feat: real UART serial reader and llama-server LLM analyzer

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -85,17 +85,44 @@ builder.Services.AddSingleton<IValidateOptions<SerialConfig>, SerialConfigValida
 builder.Services.AddSingleton<IValidateOptions<LlmConfig>, LlmConfigValidator>();
 
 // DI registrations.
-builder.Services.AddSingleton(new MockOptions { Mode = isMockFlagSet ? MockMode.Random : MockMode.Deterministic });
 builder.Services.AddSingleton<ILogRenderer, AnsiConsoleRenderer>();
-builder.Services.AddSingleton<ILlmAnalyzer, MockLlmAnalyzer>();
 
-builder.Services.AddSingleton<ISerialReader>(sp =>
+if (isMockFlagSet)
 {
-    var opts = sp.GetRequiredService<MockOptions>();
-    var log = sp.GetRequiredService<ILogger<MockSerialReader>>();
-    const int MOCK_ENTRY_DELAY_MS = 100;
-    return new MockSerialReader(opts.Mode, delay: TimeSpan.FromMilliseconds(MOCK_ENTRY_DELAY_MS), logger: log);
-});
+    builder.Services.AddSingleton(new MockOptions { Mode = MockMode.Random });
+    builder.Services.AddSingleton<ILlmAnalyzer, MockLlmAnalyzer>();
+    builder.Services.AddSingleton<ISerialReader>(sp =>
+    {
+        var opts = sp.GetRequiredService<MockOptions>();
+        var log = sp.GetRequiredService<ILogger<MockSerialReader>>();
+        const int MOCK_ENTRY_DELAY_MS = 100;
+        return new MockSerialReader(opts.Mode, delay: TimeSpan.FromMilliseconds(MOCK_ENTRY_DELAY_MS), logger: log);
+    });
+}
+else
+{
+    // Serial reader (issue #4)
+    builder.Services.AddSingleton<ISerialPortFactory, SystemSerialPortFactory>();
+    builder.Services.AddSingleton<ISerialReader>(sp =>
+    {
+        var factory = sp.GetRequiredService<ISerialPortFactory>();
+        var serialConfig = sp.GetRequiredService<IOptions<SerialConfig>>().Value;
+        var log = sp.GetRequiredService<ILogger<UartSerialReader>>();
+        return new UartSerialReader(factory, serialConfig, log);
+    });
+
+    // LLM analyzer (issue #5)
+    builder.Services.AddSingleton<LlamaServerProcess>();
+    builder.Services.AddSingleton<ILlamaServerGate>(sp => sp.GetRequiredService<LlamaServerProcess>());
+    builder.Services.AddHostedService(sp => sp.GetRequiredService<LlamaServerProcess>());
+    builder.Services.AddHttpClient("llama", (sp, client) =>
+    {
+        var llmOpts = sp.GetRequiredService<IOptions<LlmConfig>>().Value;
+        client.BaseAddress = new Uri($"http://127.0.0.1:{llmOpts.ServerPort}");
+        client.Timeout = TimeSpan.FromMilliseconds(llmOpts.TimeoutMs);
+    });
+    builder.Services.AddSingleton<ILlmAnalyzer, LlamaCppAnalyzer>();
+}
 
 builder.Services.AddHostedService<ConsoleOrchestrator>();
 

--- a/SerialSavant.csproj
+++ b/SerialSavant.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.0" />

--- a/src/Config/LlmConfig.cs
+++ b/src/Config/LlmConfig.cs
@@ -10,4 +10,5 @@ public sealed record LlmConfig
     public float Temperature { get; init; } = 0.7f;
     public int ServerPort { get; init; } = 8080;
     public int TimeoutMs { get; init; } = 30_000;
+    public string ServerPath { get; init; } = "llama-server";
 }

--- a/src/Core/LogLevelParser.cs
+++ b/src/Core/LogLevelParser.cs
@@ -1,0 +1,30 @@
+namespace SerialSavant.Core;
+
+/// <summary>
+/// Parses a <see cref="SerialLogLevel"/> from the prefix of a raw serial line.
+/// </summary>
+public static class LogLevelParser
+{
+    private static readonly (string Prefix, SerialLogLevel Level)[] Prefixes =
+    [
+        ("FATAL:", SerialLogLevel.Fatal),
+        ("ERROR:", SerialLogLevel.Error),
+        ("WARNING:", SerialLogLevel.Warning),
+        ("WARN:", SerialLogLevel.Warning),
+        ("INFO:", SerialLogLevel.Info),
+        ("DEBUG:", SerialLogLevel.Debug),
+    ];
+
+    public static SerialLogLevel Parse(string rawLine)
+    {
+        var trimmed = rawLine.AsSpan().TrimStart();
+
+        foreach (var (prefix, level) in Prefixes)
+        {
+            if (trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                return level;
+        }
+
+        return SerialLogLevel.Unknown;
+    }
+}

--- a/src/Core/LogLevelParser.cs
+++ b/src/Core/LogLevelParser.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
 namespace SerialSavant.Core;
 
 /// <summary>
@@ -17,6 +20,7 @@ public static class LogLevelParser
 
     public static SerialLogLevel Parse(string rawLine)
     {
+        ArgumentNullException.ThrowIfNull(rawLine);
         var trimmed = rawLine.AsSpan().TrimStart();
 
         foreach (var (prefix, level) in Prefixes)

--- a/src/Infrastructure/ILlamaServerGate.cs
+++ b/src/Infrastructure/ILlamaServerGate.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
 namespace SerialSavant.Infrastructure;
 
 /// <summary>

--- a/src/Infrastructure/ILlamaServerGate.cs
+++ b/src/Infrastructure/ILlamaServerGate.cs
@@ -1,0 +1,10 @@
+namespace SerialSavant.Infrastructure;
+
+/// <summary>
+/// Readiness gate for the llama-server process.
+/// Callers await <see cref="WaitForReadyAsync"/> before making HTTP calls.
+/// </summary>
+public interface ILlamaServerGate
+{
+    Task WaitForReadyAsync(CancellationToken cancellationToken);
+}

--- a/src/Infrastructure/ISerialPort.cs
+++ b/src/Infrastructure/ISerialPort.cs
@@ -1,0 +1,11 @@
+namespace SerialSavant.Infrastructure;
+
+/// <summary>
+/// Thin abstraction over a serial port connection for testability.
+/// </summary>
+public interface ISerialPort : IDisposable
+{
+    void Open();
+    Task<string?> ReadLineAsync(CancellationToken cancellationToken);
+    bool IsOpen { get; }
+}

--- a/src/Infrastructure/ISerialPort.cs
+++ b/src/Infrastructure/ISerialPort.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
 namespace SerialSavant.Infrastructure;
 
 /// <summary>

--- a/src/Infrastructure/ISerialPortFactory.cs
+++ b/src/Infrastructure/ISerialPortFactory.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
 namespace SerialSavant.Infrastructure;
 
 /// <summary>

--- a/src/Infrastructure/ISerialPortFactory.cs
+++ b/src/Infrastructure/ISerialPortFactory.cs
@@ -1,0 +1,10 @@
+namespace SerialSavant.Infrastructure;
+
+/// <summary>
+/// Creates fresh <see cref="ISerialPort"/> instances.
+/// Each reconnect attempt should request a new instance.
+/// </summary>
+public interface ISerialPortFactory
+{
+    ISerialPort Create(string portName, int baudRate);
+}

--- a/src/Infrastructure/LlamaCppAnalyzer.cs
+++ b/src/Infrastructure/LlamaCppAnalyzer.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SerialSavant.Config;
+using SerialSavant.Core;
+
+namespace SerialSavant.Infrastructure;
+
+public sealed class LlamaCppAnalyzer(
+    IHttpClientFactory httpClientFactory,
+    ILlamaServerGate serverGate,
+    IOptions<LlmConfig> options,
+    ILogger<LlamaCppAnalyzer> logger) : ILlmAnalyzer
+{
+    private const string SystemPrompt =
+        """You are an embedded systems log analyzer. For each log entry, respond with a JSON object: { "severity": "Low|Medium|High|Critical", "explanation": "<why this matters>", "suggestions": ["<action1>", "<action2>"] }. Be concise.""";
+
+    private readonly LlmConfig _config = options.Value;
+
+    public async Task<AnalysisResult> AnalyzeAsync(
+        LogEntry entry, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        await serverGate.WaitForReadyAsync(cancellationToken).ConfigureAwait(false);
+
+        var request = new ChatCompletionRequest
+        {
+            Model = "local",
+            Messages =
+            [
+                new ChatMessage { Role = "system", Content = SystemPrompt },
+                new ChatMessage { Role = "user", Content = entry.RawLine }
+            ],
+            MaxTokens = _config.MaxTokens,
+            Temperature = _config.Temperature
+        };
+
+        var requestJson = JsonSerializer.Serialize(request, LlamaCppJsonContext.Default.ChatCompletionRequest);
+        using var content = new StringContent(requestJson, System.Text.Encoding.UTF8, "application/json");
+
+        using var httpClient = httpClientFactory.CreateClient("llama");
+        using var response = await httpClient.PostAsync(
+            "/v1/chat/completions", content, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        var chatResponse = await JsonSerializer.DeserializeAsync(
+            responseStream, LlamaCppJsonContext.Default.ChatCompletionResponse,
+            cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("Empty response from llama-server.");
+
+        var assistantContent = chatResponse.Choices[0].Message.Content;
+        return ParseClassification(assistantContent);
+    }
+
+    private static AnalysisResult ParseClassification(string content)
+    {
+        try
+        {
+            var jsonStart = content.IndexOf('{');
+            var jsonEnd = content.LastIndexOf('}');
+
+            if (jsonStart < 0 || jsonEnd <= jsonStart)
+                return CreateFallback(content);
+
+            var jsonSpan = content[jsonStart..(jsonEnd + 1)];
+            var classification = JsonSerializer.Deserialize(
+                jsonSpan, LlamaCppJsonContext.Default.LlmClassification);
+
+            if (classification is null)
+                return CreateFallback(content);
+
+            var severity = Enum.TryParse<Severity>(classification.Severity, ignoreCase: true, out var parsed)
+                ? parsed
+                : Severity.Medium;
+
+            if (severity is Severity.Unknown)
+                severity = Severity.Medium;
+
+            var explanation = string.IsNullOrWhiteSpace(classification.Explanation)
+                ? content
+                : classification.Explanation;
+
+            var suggestions = classification.Suggestions?.Where(item => !string.IsNullOrWhiteSpace(item)).ToList()
+                ?? [];
+
+            if (suggestions.Count == 0)
+                suggestions = ["Review log entry manually"];
+
+            return AnalysisResult.Create(explanation, severity, suggestions);
+        }
+        catch (JsonException)
+        {
+            return CreateFallback(content);
+        }
+    }
+
+    private static AnalysisResult CreateFallback(string rawContent) =>
+        AnalysisResult.Create(
+            explanation: string.IsNullOrWhiteSpace(rawContent) ? "No analysis available" : rawContent,
+            severity: Severity.Medium,
+            suggestions: ["Review log entry manually"]);
+}

--- a/src/Infrastructure/LlamaCppAnalyzer.cs
+++ b/src/Infrastructure/LlamaCppAnalyzer.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -45,17 +48,19 @@ public sealed class LlamaCppAnalyzer(
             "/v1/chat/completions", content, cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
-        var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+        await using var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
         var chatResponse = await JsonSerializer.DeserializeAsync(
             responseStream, LlamaCppJsonContext.Default.ChatCompletionResponse,
             cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException("Empty response from llama-server.");
 
+        if (chatResponse.Choices is not { Count: > 0 })
+            throw new InvalidOperationException("llama-server returned no choices in the response.");
         var assistantContent = chatResponse.Choices[0].Message.Content;
         return ParseClassification(assistantContent);
     }
 
-    private static AnalysisResult ParseClassification(string content)
+    private AnalysisResult ParseClassification(string content)
     {
         try
         {
@@ -63,14 +68,20 @@ public sealed class LlamaCppAnalyzer(
             var jsonEnd = content.LastIndexOf('}');
 
             if (jsonStart < 0 || jsonEnd <= jsonStart)
+            {
+                logger.LogWarning("LLM response contained no JSON object, using fallback. Raw content: {Content}", content);
                 return CreateFallback(content);
+            }
 
             var jsonSpan = content[jsonStart..(jsonEnd + 1)];
             var classification = JsonSerializer.Deserialize(
                 jsonSpan, LlamaCppJsonContext.Default.LlmClassification);
 
             if (classification is null)
+            {
+                logger.LogWarning("LLM JSON deserialized to null, using fallback. Raw content: {Content}", content);
                 return CreateFallback(content);
+            }
 
             var severity = Enum.TryParse<Severity>(classification.Severity, ignoreCase: true, out var parsed)
                 ? parsed
@@ -91,8 +102,9 @@ public sealed class LlamaCppAnalyzer(
 
             return AnalysisResult.Create(explanation, severity, suggestions);
         }
-        catch (JsonException)
+        catch (JsonException ex)
         {
+            logger.LogWarning(ex, "Failed to parse LLM classification, using fallback. Raw content: {Content}", content);
             return CreateFallback(content);
         }
     }

--- a/src/Infrastructure/LlamaCppDtos.cs
+++ b/src/Infrastructure/LlamaCppDtos.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Serialization;
+
+namespace SerialSavant.Infrastructure;
+
+public sealed class ChatMessage
+{
+    [JsonPropertyName("role")]
+    public required string Role { get; set; }
+
+    [JsonPropertyName("content")]
+    public required string Content { get; set; }
+}
+
+public sealed class ChatCompletionRequest
+{
+    [JsonPropertyName("model")]
+    public required string Model { get; set; }
+
+    [JsonPropertyName("messages")]
+    public required List<ChatMessage> Messages { get; set; }
+
+    [JsonPropertyName("max_tokens")]
+    public int MaxTokens { get; set; }
+
+    [JsonPropertyName("temperature")]
+    public float Temperature { get; set; }
+}
+
+public sealed class ChatCompletionResponse
+{
+    [JsonPropertyName("id")]
+    public string? Id { get; set; }
+
+    [JsonPropertyName("choices")]
+    public required List<ChatChoice> Choices { get; set; }
+}
+
+public sealed class ChatChoice
+{
+    [JsonPropertyName("index")]
+    public int Index { get; set; }
+
+    [JsonPropertyName("message")]
+    public required ChatMessage Message { get; set; }
+
+    [JsonPropertyName("finish_reason")]
+    public string? FinishReason { get; set; }
+}
+
+public sealed class LlmClassification
+{
+    [JsonPropertyName("severity")]
+    public required string Severity { get; set; }
+
+    [JsonPropertyName("explanation")]
+    public required string Explanation { get; set; }
+
+    [JsonPropertyName("suggestions")]
+    public required List<string> Suggestions { get; set; }
+}

--- a/src/Infrastructure/LlamaCppDtos.cs
+++ b/src/Infrastructure/LlamaCppDtos.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Text.Json.Serialization;
 
 namespace SerialSavant.Infrastructure;
@@ -5,56 +8,56 @@ namespace SerialSavant.Infrastructure;
 public sealed class ChatMessage
 {
     [JsonPropertyName("role")]
-    public required string Role { get; set; }
+    public required string Role { get; init; }
 
     [JsonPropertyName("content")]
-    public required string Content { get; set; }
+    public required string Content { get; init; }
 }
 
 public sealed class ChatCompletionRequest
 {
     [JsonPropertyName("model")]
-    public required string Model { get; set; }
+    public required string Model { get; init; }
 
     [JsonPropertyName("messages")]
-    public required List<ChatMessage> Messages { get; set; }
+    public required List<ChatMessage> Messages { get; init; }
 
     [JsonPropertyName("max_tokens")]
-    public int MaxTokens { get; set; }
+    public int MaxTokens { get; init; }
 
     [JsonPropertyName("temperature")]
-    public float Temperature { get; set; }
+    public float Temperature { get; init; }
 }
 
 public sealed class ChatCompletionResponse
 {
     [JsonPropertyName("id")]
-    public string? Id { get; set; }
+    public string? Id { get; init; }
 
     [JsonPropertyName("choices")]
-    public required List<ChatChoice> Choices { get; set; }
+    public required List<ChatChoice> Choices { get; init; }
 }
 
 public sealed class ChatChoice
 {
     [JsonPropertyName("index")]
-    public int Index { get; set; }
+    public int Index { get; init; }
 
     [JsonPropertyName("message")]
-    public required ChatMessage Message { get; set; }
+    public required ChatMessage Message { get; init; }
 
     [JsonPropertyName("finish_reason")]
-    public string? FinishReason { get; set; }
+    public string? FinishReason { get; init; }
 }
 
 public sealed class LlmClassification
 {
     [JsonPropertyName("severity")]
-    public required string Severity { get; set; }
+    public required string Severity { get; init; }
 
     [JsonPropertyName("explanation")]
-    public required string Explanation { get; set; }
+    public required string Explanation { get; init; }
 
     [JsonPropertyName("suggestions")]
-    public required List<string> Suggestions { get; set; }
+    public required List<string> Suggestions { get; init; }
 }

--- a/src/Infrastructure/LlamaCppJsonContext.cs
+++ b/src/Infrastructure/LlamaCppJsonContext.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Text.Json.Serialization;
 
 namespace SerialSavant.Infrastructure;

--- a/src/Infrastructure/LlamaCppJsonContext.cs
+++ b/src/Infrastructure/LlamaCppJsonContext.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace SerialSavant.Infrastructure;
+
+[JsonSerializable(typeof(ChatCompletionRequest))]
+[JsonSerializable(typeof(ChatCompletionResponse))]
+[JsonSerializable(typeof(LlmClassification))]
+[JsonSourceGenerationOptions(
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+public sealed partial class LlamaCppJsonContext : JsonSerializerContext;

--- a/src/Infrastructure/LlamaServerProcess.cs
+++ b/src/Infrastructure/LlamaServerProcess.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Diagnostics;
 using System.Net.Http;
 using Microsoft.Extensions.Hosting;
@@ -13,7 +16,7 @@ public sealed class LlamaServerProcess : BackgroundService, ILlamaServerGate
     private readonly ILogger<LlamaServerProcess> _logger;
     private readonly TaskCompletionSource _readyTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
     private volatile bool _crashed;
-    private Process? _process;
+    private volatile Process? _process;
 
     public LlamaServerProcess(
         IOptions<LlmConfig> options,
@@ -23,14 +26,12 @@ public sealed class LlamaServerProcess : BackgroundService, ILlamaServerGate
         _logger = logger;
     }
 
-    public Task WaitForReadyAsync(CancellationToken cancellationToken)
+    public async Task WaitForReadyAsync(CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        await _readyTcs.Task.WaitAsync(cancellationToken);
         if (_crashed)
             throw new InvalidOperationException("llama-server process has exited unexpectedly.");
-
-        cancellationToken.ThrowIfCancellationRequested();
-
-        return _readyTcs.Task.WaitAsync(cancellationToken);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -69,6 +70,11 @@ public sealed class LlamaServerProcess : BackgroundService, ILlamaServerGate
         {
             _readyTcs.TrySetException(ex);
             _logger.LogError(ex, "llama-server failed to start");
+            if (_process is { HasExited: false } proc)
+            {
+                try { proc.Kill(entireProcessTree: true); } catch { }
+            }
+            _process?.Dispose();
         }
     }
 
@@ -100,9 +106,8 @@ public sealed class LlamaServerProcess : BackgroundService, ILlamaServerGate
         using var handler = new HttpClientHandler();
         using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(2) };
         var healthUrl = $"http://127.0.0.1:{_config.ServerPort}/health";
-        var deadline = DateTime.UtcNow.AddMilliseconds(_config.TimeoutMs);
-
-        while (DateTime.UtcNow < deadline)
+        var elapsed = Stopwatch.StartNew();
+        while (elapsed.ElapsedMilliseconds < _config.TimeoutMs)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
@@ -112,9 +117,9 @@ public sealed class LlamaServerProcess : BackgroundService, ILlamaServerGate
                 if (response.IsSuccessStatusCode)
                     return;
             }
-            catch (HttpRequestException)
+            catch (HttpRequestException ex)
             {
-                // Server not ready yet
+                _logger.LogDebug("Health check not ready: {Message}", ex.Message);
             }
 
             await Task.Delay(100, cancellationToken).ConfigureAwait(false);
@@ -147,7 +152,7 @@ public sealed class LlamaServerProcess : BackgroundService, ILlamaServerGate
                 using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
                 await proc.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
             }
-            catch (Exception ex) when (ex is InvalidOperationException or OperationCanceledException)
+            catch (Exception ex) when (ex is InvalidOperationException or OperationCanceledException or System.ComponentModel.Win32Exception)
             {
                 _logger.LogWarning(ex, "Error while stopping llama-server");
             }

--- a/src/Infrastructure/LlamaServerProcess.cs
+++ b/src/Infrastructure/LlamaServerProcess.cs
@@ -1,0 +1,169 @@
+using System.Diagnostics;
+using System.Net.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SerialSavant.Config;
+
+namespace SerialSavant.Infrastructure;
+
+public sealed class LlamaServerProcess : BackgroundService, ILlamaServerGate
+{
+    private readonly LlmConfig _config;
+    private readonly ILogger<LlamaServerProcess> _logger;
+    private readonly TaskCompletionSource _readyTcs = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private volatile bool _crashed;
+    private Process? _process;
+
+    public LlamaServerProcess(
+        IOptions<LlmConfig> options,
+        ILogger<LlamaServerProcess> logger)
+    {
+        _config = options.Value;
+        _logger = logger;
+    }
+
+    public Task WaitForReadyAsync(CancellationToken cancellationToken)
+    {
+        if (_crashed)
+            throw new InvalidOperationException("llama-server process has exited unexpectedly.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return _readyTcs.Task.WaitAsync(cancellationToken);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            _process = StartProcess();
+            _process.EnableRaisingEvents = true;
+            _process.Exited += OnProcessExited;
+            _process.OutputDataReceived += (_, e) =>
+            {
+                if (e.Data is not null)
+                    _logger.LogDebug("[llama-server stdout] {Line}", e.Data);
+            };
+            _process.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data is not null)
+                    _logger.LogWarning("[llama-server stderr] {Line}", e.Data);
+            };
+            _process.BeginOutputReadLine();
+            _process.BeginErrorReadLine();
+
+            await PollHealthAsync(stoppingToken).ConfigureAwait(false);
+
+            _readyTcs.TrySetResult();
+            _logger.LogInformation("llama-server is ready on port {Port}", _config.ServerPort);
+
+            // Stay alive monitoring until shutdown requested
+            await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Normal shutdown
+        }
+        catch (Exception ex)
+        {
+            _readyTcs.TrySetException(ex);
+            _logger.LogError(ex, "llama-server failed to start");
+        }
+    }
+
+    private Process StartProcess()
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = _config.ServerPath,
+            Arguments = $"--model \"{_config.ModelPath}\" --port {_config.ServerPort} --host 127.0.0.1",
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+
+        _logger.LogInformation(
+            "Starting llama-server: {Path} {Args}", startInfo.FileName, startInfo.Arguments);
+
+        return Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start process: {_config.ServerPath}");
+    }
+
+    private async Task PollHealthAsync(CancellationToken cancellationToken)
+    {
+        // Single HttpClient for the health poll loop — disposed when polling completes.
+        // Not using IHttpClientFactory here because this runs during host startup
+        // before the DI container is fully built. The client is short-lived and
+        // disposed deterministically, so socket exhaustion is not a concern.
+        using var handler = new HttpClientHandler();
+        using var client = new HttpClient(handler) { Timeout = TimeSpan.FromSeconds(2) };
+        var healthUrl = $"http://127.0.0.1:{_config.ServerPort}/health";
+        var deadline = DateTime.UtcNow.AddMilliseconds(_config.TimeoutMs);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var response = await client.GetAsync(healthUrl, cancellationToken).ConfigureAwait(false);
+                if (response.IsSuccessStatusCode)
+                    return;
+            }
+            catch (HttpRequestException)
+            {
+                // Server not ready yet
+            }
+
+            await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+        }
+
+        throw new TimeoutException(
+            $"llama-server did not become healthy within {_config.TimeoutMs}ms.");
+    }
+
+    private void OnProcessExited(object? sender, EventArgs e)
+    {
+        _crashed = true;
+        var exitCode = _process?.ExitCode;
+        _logger.LogError("llama-server exited unexpectedly with code {ExitCode}", exitCode);
+        _readyTcs.TrySetException(
+            new InvalidOperationException($"llama-server exited with code {exitCode}."));
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        if (_process is { HasExited: false } proc)
+        {
+            _logger.LogInformation("Stopping llama-server");
+            try
+            {
+                proc.Kill(entireProcessTree: true);
+
+                using var timeoutCts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                await proc.WaitForExitAsync(timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is InvalidOperationException or OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Error while stopping llama-server");
+            }
+        }
+
+        _process?.Dispose();
+        _process = null;
+    }
+
+    // Test helpers — internal for unit test access
+    internal void SimulateReady() => _readyTcs.TrySetResult();
+
+    internal void SimulateCrash()
+    {
+        _crashed = true;
+        _readyTcs.TrySetException(
+            new InvalidOperationException("llama-server exited unexpectedly (simulated)."));
+    }
+}

--- a/src/Infrastructure/SerialSavant.Infrastructure.csproj
+++ b/src/Infrastructure/SerialSavant.Infrastructure.csproj
@@ -8,7 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="SerialSavant.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageReference Include="System.IO.Ports" Version="10.0.5" />
   </ItemGroup>
 

--- a/src/Infrastructure/SerialSavant.Infrastructure.csproj
+++ b/src/Infrastructure/SerialSavant.Infrastructure.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+    <PackageReference Include="System.IO.Ports" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Infrastructure/SerialSavant.Infrastructure.csproj
+++ b/src/Infrastructure/SerialSavant.Infrastructure.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.0" />
     <PackageReference Include="System.IO.Ports" Version="10.0.5" />

--- a/src/Infrastructure/SystemSerialPort.cs
+++ b/src/Infrastructure/SystemSerialPort.cs
@@ -1,5 +1,9 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
 using System.IO.Ports;
 using System.Text;
+using Microsoft.Extensions.Logging;
 
 namespace SerialSavant.Infrastructure;
 
@@ -11,12 +15,14 @@ namespace SerialSavant.Infrastructure;
 public sealed class SystemSerialPort : ISerialPort
 {
     private readonly SerialPort _port;
+    private readonly ILogger<SystemSerialPort> _logger;
     private readonly byte[] _readBuffer = new byte[1024];
     private readonly StringBuilder _lineBuffer = new();
     private bool _disposed;
 
-    public SystemSerialPort(string portName, int baudRate)
+    public SystemSerialPort(string portName, int baudRate, ILogger<SystemSerialPort> logger)
     {
+        _logger = logger;
         _port = new SerialPort(portName, baudRate)
         {
             ReadTimeout = SerialPort.InfiniteTimeout,
@@ -26,10 +32,16 @@ public sealed class SystemSerialPort : ISerialPort
 
     public bool IsOpen => !_disposed && _port.IsOpen;
 
-    public void Open() => _port.Open();
+    public void Open()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _port.Open();
+    }
 
     public async Task<string?> ReadLineAsync(CancellationToken cancellationToken)
     {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -64,7 +76,10 @@ public sealed class SystemSerialPort : ISerialPort
         if (_port.IsOpen)
         {
             try { _port.Close(); }
-            catch (IOException) { }
+            catch (IOException ex)
+            {
+                _logger.LogDebug(ex, "IOException during serial port close on {PortName}", _port.PortName);
+            }
         }
 
         _port.Dispose();

--- a/src/Infrastructure/SystemSerialPort.cs
+++ b/src/Infrastructure/SystemSerialPort.cs
@@ -1,0 +1,72 @@
+using System.IO.Ports;
+using System.Text;
+
+namespace SerialSavant.Infrastructure;
+
+/// <summary>
+/// Production wrapper over <see cref="SerialPort"/>. Reads via
+/// <see cref="SerialPort.BaseStream"/> with manual line buffering
+/// for genuine async + cancellation support.
+/// </summary>
+public sealed class SystemSerialPort : ISerialPort
+{
+    private readonly SerialPort _port;
+    private readonly byte[] _readBuffer = new byte[1024];
+    private readonly StringBuilder _lineBuffer = new();
+    private bool _disposed;
+
+    public SystemSerialPort(string portName, int baudRate)
+    {
+        _port = new SerialPort(portName, baudRate)
+        {
+            ReadTimeout = SerialPort.InfiniteTimeout,
+            NewLine = "\n"
+        };
+    }
+
+    public bool IsOpen => !_disposed && _port.IsOpen;
+
+    public void Open() => _port.Open();
+
+    public async Task<string?> ReadLineAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Scan existing buffer for a newline without allocating ToString().
+            for (var i = 0; i < _lineBuffer.Length; i++)
+            {
+                if (_lineBuffer[i] == '\n')
+                {
+                    var lineLength = (i > 0 && _lineBuffer[i - 1] == '\r') ? i - 1 : i;
+                    var line = _lineBuffer.ToString(0, lineLength);
+                    _lineBuffer.Remove(0, i + 1);
+                    return line;
+                }
+            }
+
+            var bytesRead = await _port.BaseStream.ReadAsync(
+                _readBuffer, cancellationToken).ConfigureAwait(false);
+
+            if (bytesRead == 0)
+                return null;
+
+            _lineBuffer.Append(Encoding.UTF8.GetString(_readBuffer, 0, bytesRead));
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+
+        if (_port.IsOpen)
+        {
+            try { _port.Close(); }
+            catch (IOException) { }
+        }
+
+        _port.Dispose();
+    }
+}

--- a/src/Infrastructure/SystemSerialPortFactory.cs
+++ b/src/Infrastructure/SystemSerialPortFactory.cs
@@ -1,0 +1,7 @@
+namespace SerialSavant.Infrastructure;
+
+public sealed class SystemSerialPortFactory : ISerialPortFactory
+{
+    public ISerialPort Create(string portName, int baudRate) =>
+        new SystemSerialPort(portName, baudRate);
+}

--- a/src/Infrastructure/SystemSerialPortFactory.cs
+++ b/src/Infrastructure/SystemSerialPortFactory.cs
@@ -1,7 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
+using Microsoft.Extensions.Logging;
+
 namespace SerialSavant.Infrastructure;
 
-public sealed class SystemSerialPortFactory : ISerialPortFactory
+public sealed class SystemSerialPortFactory(ILoggerFactory loggerFactory) : ISerialPortFactory
 {
-    public ISerialPort Create(string portName, int baudRate) =>
-        new SystemSerialPort(portName, baudRate);
+    public ISerialPort Create(string portName, int baudRate)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(portName);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(baudRate);
+
+        return new SystemSerialPort(portName, baudRate, loggerFactory.CreateLogger<SystemSerialPort>());
+    }
 }

--- a/src/Infrastructure/UartSerialReader.cs
+++ b/src/Infrastructure/UartSerialReader.cs
@@ -1,0 +1,93 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.Logging;
+using SerialSavant.Config;
+using SerialSavant.Core;
+
+namespace SerialSavant.Infrastructure;
+
+public sealed class UartSerialReader(
+    ISerialPortFactory factory,
+    SerialConfig config,
+    ILogger<UartSerialReader> logger) : ISerialReader
+{
+    private ISerialPort? _currentPort;
+
+    public async IAsyncEnumerable<LogEntry> ReadAsync(
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        _currentPort = await ConnectAsync(cancellationToken).ConfigureAwait(false);
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            string? line;
+            try
+            {
+                line = await _currentPort.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                logger.LogWarning(ex, "Serial read failed on {Port}, attempting reconnect", config.Port);
+                _currentPort.Dispose();
+                _currentPort = await ConnectAsync(cancellationToken).ConfigureAwait(false);
+                continue;
+            }
+
+            if (line is null)
+                yield break;
+
+            var level = LogLevelParser.Parse(line);
+            yield return new LogEntry(DateTimeOffset.UtcNow, line, level);
+        }
+    }
+
+    private async Task<ISerialPort> ConnectAsync(CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; attempt < config.ReconnectMaxAttempts; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (attempt > 0)
+            {
+                var shift = Math.Min(attempt, 30);
+                var delayMs = Math.Min(
+                    config.ReconnectBaseDelayMs * (1 << shift),
+                    config.ReconnectMaxDelayMs);
+
+                logger.LogInformation(
+                    "Reconnecting to {Port}, attempt {Attempt}/{Max}, delay {DelayMs}ms",
+                    config.Port, attempt + 1, config.ReconnectMaxAttempts, delayMs);
+
+                await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+            }
+
+            try
+            {
+                var port = factory.Create(config.Port, config.BaudRate);
+                port.Open();
+
+                logger.LogInformation("Connected to {Port} at {BaudRate} baud",
+                    config.Port, config.BaudRate);
+
+                return port;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
+            {
+                logger.LogWarning(ex,
+                    "Failed to open {Port}, attempt {Attempt}/{Max}",
+                    config.Port, attempt + 1, config.ReconnectMaxAttempts);
+            }
+        }
+
+        throw new IOException(
+            $"Failed to connect to {config.Port} after {config.ReconnectMaxAttempts} attempts.");
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _currentPort?.Dispose();
+        _currentPort = null;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Infrastructure/UartSerialReader.cs
+++ b/src/Infrastructure/UartSerialReader.cs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
+
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging;
 using SerialSavant.Config;
@@ -51,8 +54,8 @@ public sealed class UartSerialReader(
             if (attempt > 0)
             {
                 var shift = Math.Min(attempt, 30);
-                var delayMs = Math.Min(
-                    config.ReconnectBaseDelayMs * (1 << shift),
+                var delayMs = (int)Math.Min(
+                    (long)config.ReconnectBaseDelayMs * (1L << shift),
                     config.ReconnectMaxDelayMs);
 
                 logger.LogInformation(
@@ -62,9 +65,9 @@ public sealed class UartSerialReader(
                 await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
             }
 
+            var port = factory.Create(config.Port, config.BaudRate);
             try
             {
-                var port = factory.Create(config.Port, config.BaudRate);
                 port.Open();
 
                 logger.LogInformation("Connected to {Port} at {BaudRate} baud",
@@ -74,6 +77,7 @@ public sealed class UartSerialReader(
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or InvalidOperationException)
             {
+                port.Dispose();
                 logger.LogWarning(ex,
                     "Failed to open {Port}, attempt {Attempt}/{Max}",
                     config.Port, attempt + 1, config.ReconnectMaxAttempts);

--- a/tests/SerialSavant.Tests/LlamaCppAnalyzerTests.cs
+++ b/tests/SerialSavant.Tests/LlamaCppAnalyzerTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using SerialSavant.Config;
+using SerialSavant.Core;
+using SerialSavant.Infrastructure;
+
+namespace SerialSavant.Tests;
+
+#region Test Infrastructure
+
+internal sealed class FakeLlamaServerGate(bool crashed = false) : ILlamaServerGate
+{
+    public Task WaitForReadyAsync(CancellationToken cancellationToken)
+    {
+        if (crashed)
+            throw new InvalidOperationException("Server crashed");
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class FakeHttpMessageHandler(
+    Func<HttpRequestMessage, Task<HttpResponseMessage>> handler) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken) =>
+        handler(request);
+}
+
+internal sealed class FakeHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+{
+    public HttpClient CreateClient(string name) => new(handler)
+    {
+        BaseAddress = new Uri("http://127.0.0.1:8080")
+    };
+}
+
+#endregion
+
+public sealed class LlamaCppAnalyzerTests
+{
+    private static readonly LlmConfig DefaultLlmConfig = new()
+    {
+        ModelPath = "test.gguf",
+        ServerPort = 8080,
+        MaxTokens = 512,
+        Temperature = 0.7f
+    };
+
+    private static readonly LogEntry TestEntry = new(
+        DateTimeOffset.UtcNow, "ERROR: ENOMEM - Cannot allocate memory", SerialLogLevel.Error);
+
+    private static LlamaCppAnalyzer CreateAnalyzer(
+        HttpMessageHandler handler,
+        ILlamaServerGate? gate = null,
+        LlmConfig? config = null)
+    {
+        var factory = new FakeHttpClientFactory(handler);
+        return new LlamaCppAnalyzer(
+            factory,
+            gate ?? new FakeLlamaServerGate(),
+            Options.Create(config ?? DefaultLlmConfig),
+            NullLogger<LlamaCppAnalyzer>.Instance);
+    }
+
+    private static FakeHttpMessageHandler CreateHandler(string responseContent)
+    {
+        var responseJson = JsonSerializer.Serialize(
+            new ChatCompletionResponse
+            {
+                Choices =
+                [
+                    new ChatChoice
+                    {
+                        Index = 0,
+                        Message = new ChatMessage { Role = "assistant", Content = responseContent },
+                        FinishReason = "stop"
+                    }
+                ]
+            },
+            LlamaCppJsonContext.Default.ChatCompletionResponse);
+
+        return new FakeHttpMessageHandler(_ =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(responseJson, Encoding.UTF8, "application/json")
+            }));
+    }
+
+    [Fact]
+    public async Task Given_ValidJsonResponse_When_AnalyzeAsync_Then_ReturnsCorrectResult()
+    {
+        var llmOutput = """{"severity":"High","explanation":"Memory allocation failure","suggestions":["Check heap size","Review allocations"]}""";
+        var handler = CreateHandler(llmOutput);
+        var analyzer = CreateAnalyzer(handler);
+
+        var result = await analyzer.AnalyzeAsync(TestEntry, TestContext.Current.CancellationToken);
+
+        result.Severity.Should().Be(Severity.High);
+        result.Explanation.Should().Be("Memory allocation failure");
+        result.Suggestions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Given_MalformedResponse_When_AnalyzeAsync_Then_ReturnsFallbackResult()
+    {
+        var handler = CreateHandler("I don't know how to respond in JSON, sorry!");
+        var analyzer = CreateAnalyzer(handler);
+
+        var result = await analyzer.AnalyzeAsync(TestEntry, TestContext.Current.CancellationToken);
+
+        result.Severity.Should().Be(Severity.Medium);
+        result.Explanation.Should().Contain("I don't know");
+        result.Suggestions.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Given_HttpError_When_AnalyzeAsync_Then_ThrowsHttpRequestException()
+    {
+        var handler = new FakeHttpMessageHandler(_ =>
+            Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError)));
+        var analyzer = CreateAnalyzer(handler);
+
+        var act = () => analyzer.AnalyzeAsync(TestEntry, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<HttpRequestException>();
+    }
+
+    [Fact]
+    public async Task Given_CrashedServer_When_AnalyzeAsync_Then_ThrowsInvalidOperationException()
+    {
+        var handler = CreateHandler("{}");
+        var gate = new FakeLlamaServerGate(crashed: true);
+        var analyzer = CreateAnalyzer(handler, gate);
+
+        var act = () => analyzer.AnalyzeAsync(TestEntry, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Given_Cancellation_When_AnalyzeAsync_Then_ThrowsOperationCancelled()
+    {
+        var handler = CreateHandler("{}");
+        var analyzer = CreateAnalyzer(handler);
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = () => analyzer.AnalyzeAsync(TestEntry, cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/SerialSavant.Tests/LlamaCppAnalyzerTests.cs
+++ b/tests/SerialSavant.Tests/LlamaCppAnalyzerTests.cs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -149,5 +151,58 @@ public sealed class LlamaCppAnalyzerTests
 
         var act = () => analyzer.AnalyzeAsync(TestEntry, cts.Token);
         await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task Given_JsonWrappedInProse_When_AnalyzeAsync_Then_ExtractsJsonCorrectly()
+    {
+        var llmOutput = """Sure! Here is my analysis: {"severity":"High","explanation":"OOM detected","suggestions":["Check heap size"]} Let me know if you need more.""";
+        var handler = CreateHandler(llmOutput);
+        var analyzer = CreateAnalyzer(handler);
+
+        var result = await analyzer.AnalyzeAsync(TestEntry, TestContext.Current.CancellationToken);
+
+        result.Severity.Should().Be(Severity.High);
+        result.Explanation.Should().Be("OOM detected");
+    }
+
+    [Theory]
+    [InlineData("banana")]
+    [InlineData("Unknown")]
+    [InlineData("")]
+    public async Task Given_InvalidSeverityString_When_AnalyzeAsync_Then_FallsBackToMedium(string severity)
+    {
+        var llmOutput = $$"""{"severity":"{{severity}}","explanation":"Something happened","suggestions":["Check it"]}""";
+        var handler = CreateHandler(llmOutput);
+        var analyzer = CreateAnalyzer(handler);
+
+        var result = await analyzer.AnalyzeAsync(TestEntry, TestContext.Current.CancellationToken);
+
+        result.Severity.Should().Be(Severity.Medium);
+        result.Explanation.Should().Be("Something happened");
+    }
+
+    [Fact]
+    public async Task Given_NullEntry_When_AnalyzeAsync_Then_ThrowsArgumentNullException()
+    {
+        var handler = CreateHandler("{}");
+        var analyzer = CreateAnalyzer(handler);
+
+        var act = () => analyzer.AnalyzeAsync(null!, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task Given_EmptyExplanationAndSuggestions_When_AnalyzeAsync_Then_FallsBackToDefaults()
+    {
+        var llmOutput = """{"severity":"High","explanation":"","suggestions":[]}""";
+        var handler = CreateHandler(llmOutput);
+        var analyzer = CreateAnalyzer(handler);
+
+        var result = await analyzer.AnalyzeAsync(TestEntry, TestContext.Current.CancellationToken);
+
+        result.Severity.Should().Be(Severity.High);
+        result.Explanation.Should().NotBeNullOrWhiteSpace();
+        result.Suggestions.Should().NotBeEmpty();
     }
 }

--- a/tests/SerialSavant.Tests/LlamaCppJsonTests.cs
+++ b/tests/SerialSavant.Tests/LlamaCppJsonTests.cs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
 using System.Text.Json;
 using AwesomeAssertions;
 using SerialSavant.Infrastructure;
@@ -74,5 +76,28 @@ public sealed class LlamaCppJsonTests
         result!.Severity.Should().Be("High");
         result.Explanation.Should().Be("POSIX error detected");
         result.Suggestions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Given_ResponseWithNullId_When_Serialized_Then_OmitsNullProperties()
+    {
+        var response = new ChatCompletionResponse
+        {
+            Id = null,
+            Choices =
+            [
+                new ChatChoice
+                {
+                    Index = 0,
+                    Message = new ChatMessage { Role = "assistant", Content = "test" },
+                    FinishReason = null
+                }
+            ]
+        };
+
+        var json = JsonSerializer.Serialize(response, LlamaCppJsonContext.Default.ChatCompletionResponse);
+
+        json.Should().NotContain("\"id\"");
+        json.Should().NotContain("\"finish_reason\"");
     }
 }

--- a/tests/SerialSavant.Tests/LlamaCppJsonTests.cs
+++ b/tests/SerialSavant.Tests/LlamaCppJsonTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using AwesomeAssertions;
+using SerialSavant.Infrastructure;
+
+namespace SerialSavant.Tests;
+
+public sealed class LlamaCppJsonTests
+{
+    [Fact]
+    public void Given_ChatRequest_When_Serialized_Then_RoundTrips()
+    {
+        var request = new ChatCompletionRequest
+        {
+            Model = "local",
+            Messages =
+            [
+                new ChatMessage { Role = "system", Content = "You are a log analyzer." },
+                new ChatMessage { Role = "user", Content = "ERROR: ENOMEM" }
+            ],
+            MaxTokens = 512,
+            Temperature = 0.7f
+        };
+
+        var json = JsonSerializer.Serialize(request, LlamaCppJsonContext.Default.ChatCompletionRequest);
+        var deserialized = JsonSerializer.Deserialize(json, LlamaCppJsonContext.Default.ChatCompletionRequest);
+
+        deserialized.Should().NotBeNull();
+        deserialized!.Model.Should().Be("local");
+        deserialized.Messages.Should().HaveCount(2);
+        deserialized.MaxTokens.Should().Be(512);
+    }
+
+    [Fact]
+    public void Given_ChatResponse_When_Deserialized_Then_ExtractsContent()
+    {
+        const string json = """
+        {
+            "id": "chatcmpl-123",
+            "object": "chat.completion",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": "{\"severity\":\"High\",\"explanation\":\"Memory allocation failure\",\"suggestions\":[\"Check heap size\"]}"
+                    },
+                    "finish_reason": "stop"
+                }
+            ]
+        }
+        """;
+
+        var response = JsonSerializer.Deserialize(json, LlamaCppJsonContext.Default.ChatCompletionResponse);
+
+        response.Should().NotBeNull();
+        response!.Choices.Should().HaveCount(1);
+        response.Choices[0].Message.Content.Should().Contain("Memory allocation failure");
+    }
+
+    [Fact]
+    public void Given_LlmClassification_When_Deserialized_Then_MapsFields()
+    {
+        const string json = """
+        {
+            "severity": "High",
+            "explanation": "POSIX error detected",
+            "suggestions": ["Check memory", "Review limits"]
+        }
+        """;
+
+        var result = JsonSerializer.Deserialize(json, LlamaCppJsonContext.Default.LlmClassification);
+
+        result.Should().NotBeNull();
+        result!.Severity.Should().Be("High");
+        result.Explanation.Should().Be("POSIX error detected");
+        result.Suggestions.Should().HaveCount(2);
+    }
+}

--- a/tests/SerialSavant.Tests/LlamaServerProcessTests.cs
+++ b/tests/SerialSavant.Tests/LlamaServerProcessTests.cs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
 using AwesomeAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -54,5 +56,19 @@ public sealed class LlamaServerProcessTests
 
         var act = () => process.WaitForReadyAsync(cts.Token);
         await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task Given_NotYetReady_When_WaitForReadyAsyncThenReady_Then_CompletesSuccessfully()
+    {
+        var process = new LlamaServerProcess(
+            CreateOptions(), NullLogger<LlamaServerProcess>.Instance);
+
+        var waitTask = process.WaitForReadyAsync(CancellationToken.None);
+        waitTask.IsCompleted.Should().BeFalse();
+
+        process.SimulateReady();
+
+        await waitTask; // should complete without throwing
     }
 }

--- a/tests/SerialSavant.Tests/LlamaServerProcessTests.cs
+++ b/tests/SerialSavant.Tests/LlamaServerProcessTests.cs
@@ -1,0 +1,58 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using SerialSavant.Config;
+using SerialSavant.Infrastructure;
+
+namespace SerialSavant.Tests;
+
+public sealed class LlamaServerProcessTests
+{
+    private static IOptions<LlmConfig> CreateOptions(LlmConfig? config = null) =>
+        Options.Create(config ?? new LlmConfig
+        {
+            ModelPath = "test-model.gguf",
+            ServerPort = 0, // will not actually start
+            TimeoutMs = 1000,
+            ServerPath = "llama-server"
+        });
+
+    [Fact]
+    public async Task Given_ReadyGate_When_WaitForReadyAsyncCalledAfterReady_Then_ReturnsImmediately()
+    {
+        var process = new LlamaServerProcess(
+            CreateOptions(), NullLogger<LlamaServerProcess>.Instance);
+
+        // Simulate readiness by completing the TCS externally via test helper
+        process.SimulateReady();
+
+        var task = process.WaitForReadyAsync(CancellationToken.None);
+        task.IsCompleted.Should().BeTrue();
+        await task; // should not throw
+    }
+
+    [Fact]
+    public async Task Given_CrashedServer_When_WaitForReadyAsync_Then_ThrowsInvalidOperationException()
+    {
+        var process = new LlamaServerProcess(
+            CreateOptions(), NullLogger<LlamaServerProcess>.Instance);
+
+        process.SimulateCrash();
+
+        var act = () => process.WaitForReadyAsync(CancellationToken.None);
+        await act.Should().ThrowAsync<InvalidOperationException>();
+    }
+
+    [Fact]
+    public async Task Given_CancelledToken_When_WaitForReadyAsync_Then_ThrowsOperationCancelled()
+    {
+        var process = new LlamaServerProcess(
+            CreateOptions(), NullLogger<LlamaServerProcess>.Instance);
+
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        var act = () => process.WaitForReadyAsync(cts.Token);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+}

--- a/tests/SerialSavant.Tests/LogLevelParserTests.cs
+++ b/tests/SerialSavant.Tests/LogLevelParserTests.cs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
 using AwesomeAssertions;
 using SerialSavant.Core;
 
@@ -29,11 +31,20 @@ public sealed class LogLevelParserTests
     }
 
     [Theory]
-    [InlineData("fatal: lowercase works")]
-    [InlineData("Error: mixed case")]
-    [InlineData("  INFO: leading whitespace")]
-    public void Given_LineWithVariantCasing_When_Parse_Then_MatchesCaseInsensitively(string rawLine)
+    [InlineData("fatal: lowercase works", SerialLogLevel.Fatal)]
+    [InlineData("Error: mixed case", SerialLogLevel.Error)]
+    [InlineData("  INFO: leading whitespace", SerialLogLevel.Info)]
+    public void Given_LineWithVariantCasing_When_Parse_Then_MatchesCaseInsensitively(
+        string rawLine, SerialLogLevel expected)
     {
-        LogLevelParser.Parse(rawLine).Should().NotBe(SerialLogLevel.Unknown);
+        LogLevelParser.Parse(rawLine).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("ERROR something without colon")]
+    [InlineData("INFO no colon here")]
+    public void Given_LineWithPrefixButNoColon_When_Parse_Then_ReturnsUnknown(string rawLine)
+    {
+        LogLevelParser.Parse(rawLine).Should().Be(SerialLogLevel.Unknown);
     }
 }

--- a/tests/SerialSavant.Tests/LogLevelParserTests.cs
+++ b/tests/SerialSavant.Tests/LogLevelParserTests.cs
@@ -1,0 +1,39 @@
+using AwesomeAssertions;
+using SerialSavant.Core;
+
+namespace SerialSavant.Tests;
+
+public sealed class LogLevelParserTests
+{
+    [Theory]
+    [InlineData("FATAL: something crashed", SerialLogLevel.Fatal)]
+    [InlineData("ERROR: ENOMEM - Cannot allocate memory", SerialLogLevel.Error)]
+    [InlineData("WARNING: low battery", SerialLogLevel.Warning)]
+    [InlineData("WARN: temperature high", SerialLogLevel.Warning)]
+    [InlineData("INFO: boot complete", SerialLogLevel.Info)]
+    [InlineData("DEBUG: entering main()", SerialLogLevel.Debug)]
+    public void Given_LineWithKnownPrefix_When_Parse_Then_ReturnsExpectedLevel(
+        string rawLine, SerialLogLevel expected)
+    {
+        LogLevelParser.Parse(rawLine).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("0x00 0x1A 0x2F")]
+    [InlineData("#0 0x0800ABCD in main()")]
+    [InlineData("")]
+    [InlineData("some random text")]
+    public void Given_LineWithNoKnownPrefix_When_Parse_Then_ReturnsUnknown(string rawLine)
+    {
+        LogLevelParser.Parse(rawLine).Should().Be(SerialLogLevel.Unknown);
+    }
+
+    [Theory]
+    [InlineData("fatal: lowercase works")]
+    [InlineData("Error: mixed case")]
+    [InlineData("  INFO: leading whitespace")]
+    public void Given_LineWithVariantCasing_When_Parse_Then_MatchesCaseInsensitively(string rawLine)
+    {
+        LogLevelParser.Parse(rawLine).Should().NotBe(SerialLogLevel.Unknown);
+    }
+}

--- a/tests/SerialSavant.Tests/UartSerialReaderTests.cs
+++ b/tests/SerialSavant.Tests/UartSerialReaderTests.cs
@@ -1,0 +1,205 @@
+using AwesomeAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using SerialSavant.Config;
+using SerialSavant.Core;
+using SerialSavant.Infrastructure;
+
+namespace SerialSavant.Tests;
+
+#region Test Fakes
+
+internal sealed class FakeSerialPort(Queue<string?> lines, Exception? throwAfter = null) : ISerialPort
+{
+    public bool IsOpen { get; private set; }
+    public bool Disposed { get; private set; }
+
+    public void Open() => IsOpen = true;
+
+    public Task<string?> ReadLineAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (lines.Count == 0 && throwAfter is not null)
+            throw throwAfter;
+
+        if (lines.Count == 0)
+            return Task.FromResult<string?>(null);
+
+        return Task.FromResult(lines.Dequeue());
+    }
+
+    public void Dispose()
+    {
+        IsOpen = false;
+        Disposed = true;
+    }
+}
+
+internal sealed class FakeSerialPortFactory(Queue<ISerialPort> ports) : ISerialPortFactory
+{
+    public int CreateCallCount { get; private set; }
+
+    public ISerialPort Create(string portName, int baudRate)
+    {
+        CreateCallCount++;
+        return ports.Dequeue();
+    }
+}
+
+internal sealed class FailThenSucceedFactory(int failCount, FakeSerialPort successPort) : ISerialPortFactory
+{
+    private int _attempt;
+
+    public ISerialPort Create(string portName, int baudRate)
+    {
+        _attempt++;
+        if (_attempt <= failCount)
+            return new ThrowingSerialPort();
+        return successPort;
+    }
+}
+
+internal sealed class ThrowingSerialPort : ISerialPort
+{
+    public bool IsOpen => false;
+    public void Open() => throw new IOException("Port not available");
+    public Task<string?> ReadLineAsync(CancellationToken cancellationToken) =>
+        throw new InvalidOperationException("Not open");
+    public void Dispose() { }
+}
+
+internal sealed class BlockingSerialPort : ISerialPort
+{
+    public bool IsOpen { get; private set; }
+    public void Open() => IsOpen = true;
+
+    public async Task<string?> ReadLineAsync(CancellationToken cancellationToken)
+    {
+        await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+        return null; // unreachable
+    }
+
+    public void Dispose() => IsOpen = false;
+}
+
+#endregion
+
+public sealed class UartSerialReaderTests
+{
+    private static readonly SerialConfig DefaultConfig = new()
+    {
+        Port = "COM3",
+        BaudRate = 115200,
+        ReconnectBaseDelayMs = 10,   // fast for tests
+        ReconnectMaxDelayMs = 100,
+        ReconnectMaxAttempts = 3
+    };
+
+    [Fact]
+    public async Task Given_WorkingPort_When_ReadAsync_Then_YieldsLogEntries()
+    {
+        var lines = new Queue<string?>(["ERROR: ENOMEM", "INFO: boot ok", null]);
+        var port = new FakeSerialPort(lines);
+        var factory = new FakeSerialPortFactory(new Queue<ISerialPort>([port]));
+
+        await using var reader = new UartSerialReader(factory, DefaultConfig,
+            NullLogger<UartSerialReader>.Instance);
+
+        var entries = new List<LogEntry>();
+        await foreach (var entry in reader.ReadAsync(TestContext.Current.CancellationToken))
+        {
+            entries.Add(entry);
+        }
+
+        entries.Should().HaveCount(2);
+        entries[0].LogLevel.Should().Be(SerialLogLevel.Error);
+        entries[0].RawLine.Should().Be("ERROR: ENOMEM");
+        entries[1].LogLevel.Should().Be(SerialLogLevel.Info);
+    }
+
+    [Fact]
+    public async Task Given_PortFailsThenRecovers_When_ReadAsync_Then_ReconnectsAndContinues()
+    {
+        var successLines = new Queue<string?>(["DEBUG: ok", null]);
+        var successPort = new FakeSerialPort(successLines);
+        var factory = new FailThenSucceedFactory(failCount: 2, successPort);
+
+        await using var reader = new UartSerialReader(factory, DefaultConfig,
+            NullLogger<UartSerialReader>.Instance);
+
+        var entries = new List<LogEntry>();
+        await foreach (var entry in reader.ReadAsync(TestContext.Current.CancellationToken))
+        {
+            entries.Add(entry);
+        }
+
+        entries.Should().HaveCount(1);
+        entries[0].RawLine.Should().Be("DEBUG: ok");
+    }
+
+    [Fact]
+    public async Task Given_AllReconnectsFail_When_ReadAsync_Then_ThrowsAfterMaxAttempts()
+    {
+        var factory = new FailThenSucceedFactory(failCount: 100, null!);
+
+        await using var reader = new UartSerialReader(factory, DefaultConfig,
+            NullLogger<UartSerialReader>.Instance);
+
+        var act = async () =>
+        {
+            await foreach (var _ in reader.ReadAsync(TestContext.Current.CancellationToken))
+            { }
+        };
+
+        await act.Should().ThrowAsync<IOException>();
+    }
+
+    [Fact]
+    public async Task Given_Cancellation_When_ReadAsync_Then_ExitsCleanly()
+    {
+        // Port that blocks on ReadLineAsync until cancellation
+        var blockingPort = new BlockingSerialPort();
+        var factory = new FakeSerialPortFactory(new Queue<ISerialPort>([blockingPort]));
+
+        await using var reader = new UartSerialReader(factory, DefaultConfig,
+            NullLogger<UartSerialReader>.Instance);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+        var act = async () =>
+        {
+            await foreach (var _ in reader.ReadAsync(cts.Token))
+            { }
+        };
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task Given_IoExceptionDuringRead_When_ReadAsync_Then_ReconnectsWithNewPort()
+    {
+        var failingPort = new FakeSerialPort(
+            new Queue<string?>(["INFO: first"]),
+            throwAfter: new IOException("Device disconnected"));
+
+        var recoveryLines = new Queue<string?>(["INFO: recovered", null]);
+        var recoveryPort = new FakeSerialPort(recoveryLines);
+
+        var factory = new FakeSerialPortFactory(
+            new Queue<ISerialPort>([failingPort, recoveryPort]));
+
+        await using var reader = new UartSerialReader(factory, DefaultConfig,
+            NullLogger<UartSerialReader>.Instance);
+
+        var entries = new List<LogEntry>();
+        await foreach (var entry in reader.ReadAsync(TestContext.Current.CancellationToken))
+        {
+            entries.Add(entry);
+        }
+
+        entries.Should().HaveCount(2);
+        entries[0].RawLine.Should().Be("INFO: first");
+        entries[1].RawLine.Should().Be("INFO: recovered");
+    }
+}

--- a/tests/SerialSavant.Tests/UartSerialReaderTests.cs
+++ b/tests/SerialSavant.Tests/UartSerialReaderTests.cs
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2026 Oliver Raider
+// SPDX-License-Identifier: Apache-2.0
 using AwesomeAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -201,5 +203,6 @@ public sealed class UartSerialReaderTests
         entries.Should().HaveCount(2);
         entries[0].RawLine.Should().Be("INFO: first");
         entries[1].RawLine.Should().Be("INFO: recovered");
+        failingPort.Disposed.Should().BeTrue();
     }
 }


### PR DESCRIPTION
## Summary
- **Issue #4:** Add `UartSerialReader` with `ISerialPort`/`ISerialPortFactory` abstractions, `SystemSerialPort` (BaseStream async reading), and exponential backoff reconnect logic
- **Issue #5:** Add `LlamaCppAnalyzer` with `LlamaServerProcess` (BackgroundService + readiness gate), AOT-safe chat completion DTOs via `JsonSerializerContext`, and OpenAI-compatible HTTP API client
- **DI wiring:** `Program.cs` now conditionally registers real implementations (non-mock) vs mock implementations (`--mock` flag), with `LogLevelParser` parsing device-side log levels from serial line prefixes

## New Files
| Layer | File | Purpose |
|-------|------|---------|
| Core | `LogLevelParser.cs` | Parses `SerialLogLevel` from raw line prefixes (case-insensitive) |
| Infra | `ISerialPort.cs` / `ISerialPortFactory.cs` | Testable serial port abstractions |
| Infra | `SystemSerialPort.cs` / `SystemSerialPortFactory.cs` | Production `System.IO.Ports` wrapper with async BaseStream reading |
| Infra | `UartSerialReader.cs` | `ISerialReader` impl with exponential backoff reconnect |
| Infra | `ILlamaServerGate.cs` | Readiness gate interface for llama-server |
| Infra | `LlamaCppDtos.cs` / `LlamaCppJsonContext.cs` | AOT-safe chat completion request/response DTOs |
| Infra | `LlamaServerProcess.cs` | `BackgroundService` managing llama-server child process lifecycle |
| Infra | `LlamaCppAnalyzer.cs` | `ILlmAnalyzer` impl calling llama-server HTTP API |

## Test Plan
- [x] 102 tests pass (13 LogLevelParser + 5 UartSerialReader + 3 LlamaCppJson + 3 LlamaServerProcess + 5 LlamaCppAnalyzer + 73 existing)
- [x] Release build succeeds with zero warnings
- [ ] CI matrix (Windows/Linux/macOS) passes
- [ ] Mock mode (`dotnet run -- --mock`) runs without regressions

Closes #4, closes #5